### PR TITLE
IOError with temporary files as arguments of method

### DIFF
--- a/app/controllers/bulk_upload_controller.rb
+++ b/app/controllers/bulk_upload_controller.rb
@@ -16,7 +16,8 @@ class BulkUploadController < ApplicationController
   # Each image that is uploaded comes through this action from the Flash upload tool.  They are simply
   # attached to the BulkUpload instance and we return OK or error.
   def upload
-    @bulk_upload.upload_data(params[ :data ], params[ :index ])
+    contents = {:file => params[:data]}
+    @bulk_upload.upload_data(contents, params[ :index ])
     render :text => 'DONE', :status => 200  # NOTE[md12]: Send back at least 1 non-whitespace byte for YUI Uploader to work!
   end
 
@@ -28,7 +29,7 @@ class BulkUploadController < ApplicationController
     redirect_to batch_path(batch)
   end
 
-  # This action handles cancelling a bulk upload *before* any files are being uploaded.  It does not 
+  # This action handles cancelling a bulk upload *before* any files are being uploaded.  It does not
   # handle doing it during an upload.
   def cancel
     @bulk_upload.destroy

--- a/app/models/bulk_upload.rb
+++ b/app/models/bulk_upload.rb
@@ -1,4 +1,4 @@
-# When uploading multiple images in one step an instance of this model is created for the duration 
+# When uploading multiple images in one step an instance of this model is created for the duration
 # of the upload.  This enables us to do some better error handling and dealing with the necessary
 # updates to the Batch.
 class BulkUpload < ActiveRecord::Base
@@ -17,7 +17,7 @@ class BulkUpload < ActiveRecord::Base
       match[ 1 ].to_i
     end
   end
-  
+
   has_many :images, :extend => ImagesExtension, :class_name => 'BulkUploadImage', :dependent => :destroy
 
   before_create :clean_up_leftovers!
@@ -30,7 +30,7 @@ class BulkUpload < ActiveRecord::Base
     # Because the BulkUpload could be resuming from a previously failed state we need to destroy all of
     # the Image instances that may occupy our position.
     self.images.in_position(index).each {|i| i.destroy}
-    self.images.create!(:data => source, :position => index)
+    self.images.create!(:data => source[:file], :position => index)
   end
 
   # Attaches all of the images that have been uploaded within this bulk upload to the specified Batch
@@ -79,7 +79,7 @@ private
         Image.for_batch(batch).all.each(&:destroy)
         Image.insert_from_bulk_upload(self)
       end
-      
+
       batch
     end
   end


### PR DESCRIPTION
File is read and closed when its reference is passed to the model underneath and this creates an IOError. Fix applied by wrapping the File in an object
